### PR TITLE
Supress emoji printing on non-unicode terminals

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,13 @@
 const prettyBytes = require('prettier-bytes');
 const jsonParse = require('fast-json-parse');
+const hasUnicode = require('has-unicode')();
 const prettyMs = require('pretty-ms');
 const padLeft = require('pad-left');
 const chalk = require('chalk');
 const flat = require('flat');
 const yaml = require('js-yaml');
-const nl = '\n';
+
+const nl = process.platform === 'win32' ? '\r\n' : '\n';
 
 const emojiLog = {
     fatal: '💀',
@@ -178,8 +180,8 @@ function MiamiVice() {
         
         const errLines = yaml.safeDump(err, { skipInvalid: true })
             .split(anynl).map(errLine => '   ' + errLine);
-        errLines.unshift(`${emojiMark.error} ${errName}:`);
-        
+        errLines.unshift(`${formatMark(emojiMark.error)} ${errName}:`);
+
         return errLines
             .filter(errLine => errLine.trim())
             .map(indent);
@@ -195,13 +197,13 @@ function MiamiVice() {
         const errNameMatch = trace[0].match(errorNameRegex);
         if (!err) {
             let errName = errNameMatch ? errNameMatch[1] : 'Error';
-            res.push(`${emojiMark.error} ${errName}:`);
+            res.push(`${formatMark(emojiMark.error)} ${errName}:`);
         }
         if (errNameMatch) {
             trace.shift();
         }
 
-        res.push(`${emojiMark.stack} Stack trace:`);
+        res.push(`${formatMark(emojiMark.stack)} Stack trace:`);
         res.push(...trace);
         return res.map(indent);
     }
@@ -216,9 +218,10 @@ function MiamiVice() {
     }
 
     function formatLevel(level) {
+        if (!hasUnicode) return level;
         const emoji = emojiLog[level];
         const padding = isWideEmoji(emoji) ? '' : ' ';
-        return emoji + padding
+        return emoji + padding;
     }
 
     function formatNs(name) {
@@ -284,6 +287,10 @@ function MiamiVice() {
         if (message === 'request' || message === 'incoming request') return '<--';
         if (message === 'response' || message === 'request completed') return '-->';
         return message
+    }
+
+    function formatMark(mark) {
+        return hasUnicode ? mark : '';
     }
 
     function noEmpty(val) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,11 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+    },
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -15,13 +15,14 @@
     "miami-vice": "./bin.js"
   },
   "dependencies": {
-    "prettier-bytes": "^1.0.4",
-    "fast-json-parse": "^1.0.3",
-    "pretty-ms": "^5.0.0",
-    "pad-left": "^2.1.0",
-    "split2": "^3.1.1",
     "chalk": "^2.4.2",
+    "fast-json-parse": "^1.0.3",
     "flat": "^5.0.0",
-    "js-yaml": "^3.13.1"
+    "has-unicode": "^2.0.1",
+    "js-yaml": "^3.13.1",
+    "pad-left": "^2.1.0",
+    "prettier-bytes": "^1.0.4",
+    "pretty-ms": "^5.0.0",
+    "split2": "^3.1.1"
   }
 }


### PR DESCRIPTION
This resolves #5.  It now checks if the platform is 'win32' (covers all Windows versions), then prints an empty string instead of an emoji.  Also, sets new line to CRLF on Windows.