### PR TITLE
Colorize log level on non-unicode terminals

### DIFF
--- a/index.js
+++ b/index.js
@@ -218,7 +218,7 @@ function MiamiVice() {
     }
 
     function formatLevel(level) {
-        if (!hasUnicode) return level;
+        if (!hasUnicode) return formatMessage(level, level);
         const emoji = emojiLog[level];
         const padding = isWideEmoji(emoji) ? '' : ' ';
         return emoji + padding;


### PR DESCRIPTION
This makes the log level the same color as the log message on non-unicode terminals
![non-uni](https://user-images.githubusercontent.com/7145645/75127099-cfc8c500-5682-11ea-828a-f46198bfabe1.png)
.